### PR TITLE
Fix some portability issues on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pipeviz
 *.o
 moc_*
 src/version_info.h
+pipeviz.pro.user

--- a/gstreamer.prf
+++ b/gstreamer.prf
@@ -1,0 +1,51 @@
+# =============================================================
+# This optional feature file adds GStreamer dependencies
+# =============================================================
+unix {
+    CONFIG    += link_pkgconfig
+    PKGCONFIG += gstreamer-1.0
+} else {
+
+    GSTREAMER_PATH = $$clean_path($$(GSTREAMER_1_0_ROOT_X86))
+    if(isEmpty(GSTREAMER_PATH)) {
+        GSTREAMER_PATH = $$clean_path($$(GSTREAMER_1_0_ROOT_X86_64))
+    }
+
+    if(isEmpty(GSTREAMER_PATH)|!exists($${GSTREAMER_PATH})) {
+
+        text = "\"GStreamer\" not found: to be able to use the debugger, don't forget to add"
+        text = "$${text} \"%GSTREAMER_1_0_ROOT_X86_64%\bin\" in your PATH"
+        !build:warning("$${text}")
+
+    } else {
+
+        DEFINES += GST_USE_UNSTABLE_API
+
+        GST_INCLUDEPATH = \
+            $$clean_path($$GSTREAMER_PATH/include/gstreamer-1.0) \
+            $$clean_path($$GSTREAMER_PATH/include/glib-2.0) \
+            $$clean_path($$GSTREAMER_PATH/lib/glib-2.0/include)
+        *-g++ {
+            # To avoid warnings due to GStreamer, use -isystem automatically for any GStreamer system header:
+            for(somelib, $$list($$GST_INCLUDEPATH)) {
+                QMAKE_CXXFLAGS += -isystem $${somelib}
+            }
+        } else {
+            INCLUDEPATH += $${GST_INCLUDEPATH}
+        }
+        unset(GST_INCLUDEPATH)
+
+        win32-g++ {
+            LIBS += \
+                $${GSTREAMER_PATH}/lib/glib-2.0.lib \
+                $${GSTREAMER_PATH}/lib/gobject-2.0.lib \
+                $${GSTREAMER_PATH}/lib/gstreamer-1.0.lib
+        } else {
+            LIBS += \
+                -L$$GSTREAMER_PATH/lib \
+                -lglib-2.0 \
+                -lgobject-2.0 \
+                -lgstreamer-1.0
+        }
+    } # GStreamer found
+}

--- a/pipeviz.pri
+++ b/pipeviz.pri
@@ -10,7 +10,7 @@ QT += xml
 QT += core
 INCLUDEPATH += . src 
 
-CONFIG += link_pkgconfig
+CONFIG += gstreamer
 
 QMAKE_CXXFLAGS += -std=c++11
 

--- a/pipeviz.pro
+++ b/pipeviz.pro
@@ -1,4 +1,5 @@
+# Location of our own features:
+command = $$[QT_INSTALL_BINS]/qmake -set QMAKEFEATURES $$_PRO_FILE_PWD_
+system($$command)|error("Failed to run: $$command")
+
 include(pipeviz.pri)
-
-PKGCONFIG += gstreamer-1.0
-


### PR DESCRIPTION
- Remove usage of Linux specific headers (in Logger)
- Adding the gstreamer.prf feature to easily find GStreamer on Windows
- Adding "pipeviz.pro.user" to the ignore list

NB : The Logger class could be modified to only use QT classes (instead of functions like snprintf).
