### PR TITLE
Update readme after recent build scheme changes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Building:
 
 cd pipeviz
 
-qmake pipeviz.pro
+QMAKEFEATURES=. qmake pipeviz.pro
 
 make gitinfo
 


### PR DESCRIPTION
Because gstreamer.prf is created and gstreamer configuration
is removed from pipeviz.pri/pro, QMAKEFEATURES should be
configured for pipeviz qmake execution.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>